### PR TITLE
Frontend API wiring: Prisma Studio, forms/workflows queries, login fix

### DIFF
--- a/apps/web/graphql/forms/forms.hooks.ts
+++ b/apps/web/graphql/forms/forms.hooks.ts
@@ -2,24 +2,21 @@ import { useMutation, useQuery } from "@apollo/client/react";
 
 import {
   CREATE_FORM_DEFINITION,
+  UPDATE_FORM_DEFINITION,
   PUBLISH_FORM,
   ARCHIVE_FORM,
   SUBMIT_FORM,
-  UPDATE_SUBMISSION_STATUS,
 } from "./forms.mutations";
 import {
   GET_FORM_DEFINITION,
   GET_FORM_DEFINITIONS,
-  GET_FORM_FIELD_TYPES,
   GET_FORM_SUBMISSIONS,
 } from "./forms.queries";
 import type {
   FormDefinitionData,
   FormDefinitionsData,
-  FormFieldTypesData,
   FormSubmissionsData,
   MutationResultData,
-  SubmitFormData,
 } from "./forms.types";
 
 export const useFormDefinitions = (status?: string) => {
@@ -39,24 +36,22 @@ export const useFormDefinition = (slug: string) => {
   return { form: data?.formDefinition ?? null, loading, error };
 };
 
-export const useFormSubmissions = (slug: string, status?: string) => {
+export const useFormSubmissions = (formId: string) => {
   const { data, loading, error, refetch } = useQuery<FormSubmissionsData>(GET_FORM_SUBMISSIONS, {
-    variables: { slug, status },
+    variables: { formId },
     fetchPolicy: "cache-and-network",
-    skip: !slug,
+    skip: !formId,
   });
   return { submissions: data?.formSubmissions ?? [], loading, error, refetch };
 };
 
-export const useFormFieldTypes = () => {
-  const { data, loading } = useQuery<FormFieldTypesData>(GET_FORM_FIELD_TYPES, {
-    fetchPolicy: "cache-first",
-  });
-  return { fieldTypes: data?.formFieldTypes ?? [], loading };
-};
-
 export const useCreateFormDefinition = () =>
   useMutation<MutationResultData>(CREATE_FORM_DEFINITION, {
+    refetchQueries: [GET_FORM_DEFINITIONS],
+  });
+
+export const useUpdateFormDefinition = () =>
+  useMutation<MutationResultData>(UPDATE_FORM_DEFINITION, {
     refetchQueries: [GET_FORM_DEFINITIONS],
   });
 
@@ -71,7 +66,4 @@ export const useArchiveForm = () =>
   });
 
 export const useSubmitForm = () =>
-  useMutation<SubmitFormData>(SUBMIT_FORM);
-
-export const useUpdateSubmissionStatus = () =>
-  useMutation<MutationResultData>(UPDATE_SUBMISSION_STATUS);
+  useMutation<MutationResultData>(SUBMIT_FORM);

--- a/apps/web/graphql/forms/forms.mutations.ts
+++ b/apps/web/graphql/forms/forms.mutations.ts
@@ -1,61 +1,94 @@
 import { gql } from "@apollo/client";
 
 export const CREATE_FORM_DEFINITION = gql`
-  mutation CreateFormDefinition($input: FormDefinitionInput!) {
-    createFormDefinition(input: $input) {
+  mutation CreateFormDefinition(
+    $name: String!
+    $slug: String!
+    $description: String
+    $formType: String
+    $isPublic: Boolean
+    $schema: JSON
+    $fieldConfig: JSON
+    $logicRules: JSON
+  ) {
+    createFormDefinition(
+      name: $name
+      slug: $slug
+      description: $description
+      formType: $formType
+      isPublic: $isPublic
+      schema: $schema
+      fieldConfig: $fieldConfig
+      logicRules: $logicRules
+    ) {
       ok
       errors {
         field
-        messages
+        message
+      }
+    }
+  }
+`;
+
+export const UPDATE_FORM_DEFINITION = gql`
+  mutation UpdateFormDefinition(
+    $id: String!
+    $name: String
+    $description: String
+    $schema: JSON
+    $fieldConfig: JSON
+    $logicRules: JSON
+    $isPublic: Boolean
+  ) {
+    updateFormDefinition(
+      id: $id
+      name: $name
+      description: $description
+      schema: $schema
+      fieldConfig: $fieldConfig
+      logicRules: $logicRules
+      isPublic: $isPublic
+    ) {
+      ok
+      errors {
+        field
+        message
       }
     }
   }
 `;
 
 export const PUBLISH_FORM = gql`
-  mutation PublishForm($slug: String!) {
-    publishForm(slug: $slug) {
+  mutation PublishFormDefinition($id: String!) {
+    publishFormDefinition(id: $id) {
       ok
       errors {
         field
-        messages
+        message
       }
     }
   }
 `;
 
 export const ARCHIVE_FORM = gql`
-  mutation ArchiveForm($slug: String!) {
-    archiveForm(slug: $slug) {
+  mutation ArchiveFormDefinition($id: String!) {
+    archiveFormDefinition(id: $id) {
       ok
       errors {
         field
-        messages
+        message
       }
     }
   }
 `;
 
 export const SUBMIT_FORM = gql`
-  mutation SubmitForm($slug: String!, $payload: JSON!) {
-    submitForm(slug: $slug, payload: $payload) {
-      ok
-      submissionId
-      errors {
-        field
-        messages
-      }
-    }
-  }
-`;
-
-export const UPDATE_SUBMISSION_STATUS = gql`
-  mutation UpdateSubmissionStatus($submissionId: ID!, $status: String!) {
-    updateSubmissionStatus(submissionId: $submissionId, status: $status) {
+  mutation SubmitForm($formId: String!, $payload: JSON!) {
+    submitForm(formId: $formId, payload: $payload) {
       ok
       errors {
         field
-        messages
+        message
       }
     }
   }

--- a/apps/web/graphql/forms/forms.queries.ts
+++ b/apps/web/graphql/forms/forms.queries.ts
@@ -3,6 +3,7 @@ import { gql } from "@apollo/client";
 export const GET_FORM_DEFINITIONS = gql`
   query GetFormDefinitions($status: String) {
     formDefinitions(status: $status) {
+      id
       name
       slug
       description
@@ -21,6 +22,7 @@ export const GET_FORM_DEFINITIONS = gql`
 export const GET_FORM_DEFINITION = gql`
   query GetFormDefinition($slug: String!) {
     formDefinition(slug: $slug) {
+      id
       name
       slug
       description
@@ -41,21 +43,12 @@ export const GET_FORM_DEFINITION = gql`
 `;
 
 export const GET_FORM_SUBMISSIONS = gql`
-  query GetFormSubmissions($slug: String!, $status: String) {
-    formSubmissions(slug: $slug, status: $status) {
+  query GetFormSubmissions($formId: String!) {
+    formSubmissions(formId: $formId) {
+      id
       payload
       status
       submittedAt
-      createdAt
-      formName
-      formVersion
-      formSlug
     }
-  }
-`;
-
-export const GET_FORM_FIELD_TYPES = gql`
-  query GetFormFieldTypes {
-    formFieldTypes
   }
 `;

--- a/apps/web/graphql/forms/forms.types.ts
+++ b/apps/web/graphql/forms/forms.types.ts
@@ -1,12 +1,16 @@
 export type FormDefinition = {
+  id: string;
   name: string;
   slug: string;
-  description: string;
+  description: string | null;
   status: string;
   version: number;
   schema: Record<string, unknown>;
-  formType?: string;
-  isPublic?: boolean;
+  formType: string;
+  isPublic: boolean;
+  fieldConfig: Record<string, unknown>;
+  logicRules: unknown[];
+  scoring: Record<string, unknown> | null;
   publishedAt: string | null;
   createdAt: string;
   updatedAt: string;
@@ -14,13 +18,10 @@ export type FormDefinition = {
 };
 
 export type FormSubmission = {
+  id: string;
   payload: Record<string, unknown>;
   status: string;
   submittedAt: string;
-  createdAt: string;
-  formName: string;
-  formVersion: number;
-  formSlug: string;
 };
 
 export type FormDefinitionsData = {
@@ -35,21 +36,14 @@ export type FormSubmissionsData = {
   formSubmissions: FormSubmission[];
 };
 
-export type FormFieldTypesData = {
-  formFieldTypes: string[];
-};
-
-export type SubmitFormData = {
-  submitForm: {
-    ok: boolean;
-    submissionId: string | null;
-    errors: { field: string; messages: string[] }[];
-  };
+export type MutationError = {
+  field: string | null;
+  message: string;
 };
 
 export type MutationResultData = {
   [key: string]: {
     ok: boolean;
-    errors: { field: string; messages: string[] }[];
+    errors: MutationError[] | null;
   };
 };

--- a/apps/web/graphql/workflows/workflows.mutations.ts
+++ b/apps/web/graphql/workflows/workflows.mutations.ts
@@ -4,7 +4,7 @@ export const CREATE_WORKFLOW = gql`
   mutation CreateWorkflowDefinition(
     $name: String!
     $slug: String!
-    $modelLabel: String!
+    $modelName: String!
     $states: JSON!
     $transitions: JSON!
     $description: String
@@ -13,7 +13,7 @@ export const CREATE_WORKFLOW = gql`
     createWorkflowDefinition(
       name: $name
       slug: $slug
-      modelLabel: $modelLabel
+      modelName: $modelName
       states: $states
       transitions: $transitions
       description: $description
@@ -22,7 +22,7 @@ export const CREATE_WORKFLOW = gql`
       ok
       errors {
         field
-        messages
+        message
       }
     }
   }
@@ -33,7 +33,7 @@ export const UPDATE_WORKFLOW = gql`
     $slug: String!
     $name: String
     $description: String
-    $modelLabel: String
+    $modelName: String
     $states: JSON
     $transitions: JSON
     $isEnabled: Boolean
@@ -42,7 +42,7 @@ export const UPDATE_WORKFLOW = gql`
       slug: $slug
       name: $name
       description: $description
-      modelLabel: $modelLabel
+      modelName: $modelName
       states: $states
       transitions: $transitions
       isEnabled: $isEnabled
@@ -50,7 +50,7 @@ export const UPDATE_WORKFLOW = gql`
       ok
       errors {
         field
-        messages
+        message
       }
     }
   }
@@ -62,20 +62,19 @@ export const DELETE_WORKFLOW = gql`
       ok
       errors {
         field
-        messages
+        message
       }
     }
   }
 `;
 
 export const START_WORKFLOW = gql`
-  mutation StartWorkflow($workflowSlug: String!, $modelLabel: String!, $objectId: Int!) {
-    startWorkflow(workflowSlug: $workflowSlug, modelLabel: $modelLabel, objectId: $objectId) {
+  mutation StartWorkflow($workflowSlug: String!, $targetModel: String!, $targetId: String!) {
+    startWorkflow(workflowSlug: $workflowSlug, targetModel: $targetModel, targetId: $targetId) {
       ok
-      instanceId
       errors {
         field
-        messages
+        message
       }
     }
   }
@@ -87,7 +86,7 @@ export const TRANSITION_WORKFLOW = gql`
       ok
       errors {
         field
-        messages
+        message
       }
     }
   }

--- a/apps/web/graphql/workflows/workflows.queries.ts
+++ b/apps/web/graphql/workflows/workflows.queries.ts
@@ -1,16 +1,16 @@
 import { gql } from "@apollo/client";
 
 export const GET_WORKFLOWS = gql`
-  query GetWorkflows($modelLabel: String) {
-    workflowDefinitions(modelLabel: $modelLabel) {
+  query GetWorkflows($modelName: String) {
+    workflowDefinitions(modelName: $modelName) {
+      id
       name
       slug
       description
-      modelLabel
+      modelName
       isEnabled
       createdAt
       instanceCount
-      activeInstanceCount
     }
   }
 `;
@@ -18,16 +18,16 @@ export const GET_WORKFLOWS = gql`
 export const GET_WORKFLOW = gql`
   query GetWorkflow($slug: String!) {
     workflowDefinition(slug: $slug) {
+      id
       name
       slug
       description
-      modelLabel
+      modelName
       states
       transitions
       isEnabled
       createdAt
       instanceCount
-      activeInstanceCount
     }
   }
 `;

--- a/apps/web/graphql/workflows/workflows.types.ts
+++ b/apps/web/graphql/workflows/workflows.types.ts
@@ -18,7 +18,7 @@ export type WorkflowDefinition = {
   name: string;
   slug: string;
   description: string | null;
-  modelLabel: string;
+  modelName: string;
   states: WorkflowState[];
   transitions: WorkflowTransition[];
   isEnabled: boolean;

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -61,6 +61,19 @@ services:
       timeout: 3s
       retries: 5
 
+  studio:
+    build:
+      context: ../apps/api
+      dockerfile: ../../docker/Dockerfile.api
+    command: npx prisma studio --port 5555 --hostname 0.0.0.0
+    ports:
+      - "5555:5555"
+    env_file:
+      - ../local.env
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   minio:
     image: minio/minio
     command: server /data --console-address ":9001"


### PR DESCRIPTION
## Summary
- Prisma Studio added to Docker Compose at :5555 (visual DB browser)
- All frontend GraphQL queries/mutations/types aligned with NestJS API
- Login page: password form + Auth0 SSO button (no redirect loop)
- Callback page: handles both Auth0 code exchange and password token

## Changes
- Forms: queries use `formId` not `slug`, flat mutation args, `message` not `messages`
- Workflows: `modelLabel` → `modelName`, `objectId` → `targetId`
- NavUser: `profile.username` → `name`
- Docker Compose: Prisma Studio service at :5555

Closes #77, #78

## Test plan
- [x] Login form works with password
- [x] Dashboard loads after auth
- [x] Prisma Studio at :5555 shows all models
- [x] Forms/workflows pages should render (queries match API schema)