### PR TITLE
Auth0 auto-group assignment + Chrome-verified frontend

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -101,10 +101,18 @@ export class AuthController {
     });
 
     if (!user) {
+      // Auto-assign new users to the Viewer group by default
+      const defaultGroup = await this.prisma.group.findUnique({
+        where: { name: "Viewer" },
+      });
+
       user = await this.prisma.user.create({
         data: {
           email: userInfo.email,
           name: userInfo.name || userInfo.nickname || userInfo.email,
+          ...(defaultGroup
+            ? { groups: { create: { groupId: defaultGroup.id } } }
+            : {}),
         },
       });
     }


### PR DESCRIPTION
## Summary
- Auto-assign new Auth0 users to Viewer group (default permissions)
- Verified all pages in Chrome with authenticated user

## Verified in Chrome
- [x] Dashboard: summary cards, revenue/channels/sales charts render
- [x] Forms page: heading, description, "New Form" link, no permission errors
- [x] Workflows page: heading, description, "New Workflow" link, sidebar expanded
- [x] Auth: Leo Mata / lmata@weareconflict.com shown in sidebar
- [x] Breadcrumbs working
- [x] Dark mode toggle present
- [x] Language switcher present