### PR TITLE
Form builder + Workflow builder verified in Chrome

### DIFF
--- a/apps/web/app/(app)/workflows/[slug]/builder/page.tsx
+++ b/apps/web/app/(app)/workflows/[slug]/builder/page.tsx
@@ -48,7 +48,7 @@ export default function WorkflowBuilderPage() {
       const errors = data?.updateWorkflowDefinition?.errors ?? [];
       if (errors.length > 0) {
         for (const e of errors) {
-          toast.error(`${e.field}: ${e.messages.join(", ")}`);
+          toast.error(`${e.field}: ${e.message}`);
         }
       } else {
         toast.error("Failed to save workflow");

--- a/apps/web/graphql/workflows/workflows.hooks.ts
+++ b/apps/web/graphql/workflows/workflows.hooks.ts
@@ -18,9 +18,9 @@ import type {
   WorkflowDefinitionsData,
 } from "./workflows.types";
 
-export const useWorkflows = (modelLabel?: string) => {
+export const useWorkflows = (modelName?: string) => {
   const { data, loading, error, refetch } = useQuery<WorkflowDefinitionsData>(GET_WORKFLOWS, {
-    variables: { modelLabel },
+    variables: { modelName },
     fetchPolicy: "cache-and-network",
   });
   return { workflows: data?.workflowDefinitions ?? [], loading, error, refetch };

--- a/apps/web/graphql/workflows/workflows.types.ts
+++ b/apps/web/graphql/workflows/workflows.types.ts
@@ -24,7 +24,6 @@ export type WorkflowDefinition = {
   isEnabled: boolean;
   createdAt: string;
   instanceCount: number;
-  activeInstanceCount: number;
 };
 
 export type WorkflowDefinitionsData = {
@@ -36,8 +35,8 @@ export type WorkflowDefinitionData = {
 };
 
 export type MutationError = {
-  field: string;
-  messages: string[];
+  field: string | null;
+  message: string;
 };
 
 export type WorkflowMutationResult = {


### PR DESCRIPTION
## Summary
Fixed remaining type/query mismatches so form and workflow builders render correctly.

## Verified in Chrome
- [x] Form builder: visual field editor with drag-and-drop, live preview
- [x] Workflow builder: ReactFlow canvas with 3 states, 2 transitions from API
- [x] State badges: "Start" on Draft, "End" on Approved
- [x] Transition labels: "Submit", "Approve"
- [x] Add State / Save Workflow buttons present
- [x] Minimap rendering

## Fixes
- `modelLabel` → `modelName` in workflow hooks
- `messages` → `message` in workflow types/builder page
- Removed `activeInstanceCount` from types (not in API)

Closes #26, #27, #31