### PR TITLE
Prisma soft-delete, interceptors, schema export

### DIFF
--- a/apps/api/scripts/export-schema.ts
+++ b/apps/api/scripts/export-schema.ts
@@ -1,0 +1,8 @@
+import { printSchema } from "graphql";
+import { writeFileSync } from "fs";
+import { schema } from "../src/graphql/schema";
+
+const sdl = printSchema(schema);
+writeFileSync("schema.graphql", sdl);
+console.log("Schema exported to apps/api/schema.graphql");
+console.log(`${sdl.split("\n").length} lines`);

--- a/apps/api/src/common/interceptors/logging.interceptor.ts
+++ b/apps/api/src/common/interceptors/logging.interceptor.ts
@@ -1,0 +1,26 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from "@nestjs/common";
+import { Observable, tap } from "rxjs";
+
+@Injectable()
+export class LoggingInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const req = context.switchToHttp().getRequest();
+    const method = req?.method ?? "UNKNOWN";
+    const url = req?.url ?? "UNKNOWN";
+    const start = Date.now();
+
+    return next.handle().pipe(
+      tap(() => {
+        const duration = Date.now() - start;
+        if (url !== "/health") {
+          console.log(`${method} ${url} ${duration}ms`);
+        }
+      }),
+    );
+  }
+}

--- a/apps/api/src/common/interceptors/timeout.interceptor.ts
+++ b/apps/api/src/common/interceptors/timeout.interceptor.ts
@@ -1,0 +1,29 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  RequestTimeoutException,
+} from "@nestjs/common";
+import { Observable, throwError, timeout, catchError, TimeoutError } from "rxjs";
+
+@Injectable()
+export class TimeoutInterceptor implements NestInterceptor {
+  private readonly timeoutMs: number;
+
+  constructor(timeoutMs = 30_000) {
+    this.timeoutMs = timeoutMs;
+  }
+
+  intercept(_context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    return next.handle().pipe(
+      timeout(this.timeoutMs),
+      catchError((err) => {
+        if (err instanceof TimeoutError) {
+          return throwError(() => new RequestTimeoutException());
+        }
+        return throwError(() => err);
+      }),
+    );
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -3,6 +3,8 @@ import * as cookieParser from "cookie-parser";
 import helmet from "helmet";
 import { AppModule } from "./app.module";
 import { AllExceptionsFilter } from "./common/filters/all-exceptions.filter";
+import { LoggingInterceptor } from "./common/interceptors/logging.interceptor";
+import { TimeoutInterceptor } from "./common/interceptors/timeout.interceptor";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -21,8 +23,9 @@ async function bootstrap() {
     credentials: true,
   });
 
-  // Global exception filter
+  // Global filters + interceptors
   app.useGlobalFilters(new AllExceptionsFilter());
+  app.useGlobalInterceptors(new LoggingInterceptor(), new TimeoutInterceptor());
 
   const port = process.env.PORT ?? 4000;
   await app.listen(port);

--- a/apps/api/src/prisma/extensions/soft-delete.ts
+++ b/apps/api/src/prisma/extensions/soft-delete.ts
@@ -1,0 +1,38 @@
+import { Prisma } from "@prisma/client";
+
+// Models that use soft-delete via deletedAt field
+const SOFT_DELETE_MODELS = [
+  "FormDefinition",
+  "WorkflowDefinition",
+  "Upload",
+];
+
+/**
+ * Prisma extension for soft-delete behavior:
+ * - findMany/findFirst automatically filter out deleted records
+ */
+export const softDeleteExtension = Prisma.defineExtension({
+  name: "soft-delete",
+  query: {
+    $allModels: {
+      async findMany({ model, args, query }) {
+        if (SOFT_DELETE_MODELS.includes(model)) {
+          const where = args.where as Record<string, unknown> | undefined;
+          if (!where?.deletedAt) {
+            args.where = { ...args.where, deletedAt: null } as unknown as typeof args.where;
+          }
+        }
+        return query(args);
+      },
+      async findFirst({ model, args, query }) {
+        if (SOFT_DELETE_MODELS.includes(model)) {
+          const where = args.where as Record<string, unknown> | undefined;
+          if (!where?.deletedAt) {
+            args.where = { ...args.where, deletedAt: null } as unknown as typeof args.where;
+          }
+        }
+        return query(args);
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Prisma soft-delete extension (auto-filters deletedAt)
- Request logging interceptor (method/url/duration)
- Timeout interceptor (30s default)
- GraphQL schema export script

Closes #63, #80, #81

## Test plan
- [x] API builds cleanly
- [x] Soft-delete extension compiles with type casts
- [x] Interceptors wired into main.ts