### PR TITLE
Organization model + API keys

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -26,12 +26,14 @@ model User {
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
-  groups          UserGroup[]
-  sessions        Session[]
-  formSubmissions FormSubmission[]
-  transitionLogs  TransitionLog[]
-  notifications   Notification[]
-  auditLogs       AuditLog[]
+  groups              UserGroup[]
+  sessions            Session[]
+  formSubmissions     FormSubmission[]
+  transitionLogs      TransitionLog[]
+  notifications       Notification[]
+  auditLogs           AuditLog[]
+  organizationMembers OrganizationMember[]
+  apiKeys             ApiKey[]
 }
 
 model Group {
@@ -213,4 +215,47 @@ model AuditLog {
 
   @@index([userId])
   @@index([targetType, targetId])
+}
+
+// --- Organizations ---
+
+model Organization {
+  id        String   @id @default(cuid())
+  name      String
+  slug      String   @unique
+  settings  Json     @default("{}")
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  deletedAt DateTime?
+
+  members OrganizationMember[]
+}
+
+model OrganizationMember {
+  id             String       @id @default(cuid())
+  userId         String
+  user           User         @relation(fields: [userId], references: [id])
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  role           String       @default("member") // owner, admin, member
+  joinedAt       DateTime     @default(now())
+
+  @@unique([userId, organizationId])
+}
+
+// --- API Keys ---
+
+model ApiKey {
+  id          String    @id @default(cuid())
+  name        String
+  keyHash     String    @unique
+  keyPrefix   String    // first 8 chars for identification
+  permissions Json      @default("[]")
+  createdById String
+  createdBy   User      @relation(fields: [createdById], references: [id])
+  lastUsedAt  DateTime?
+  expiresAt   DateTime?
+  createdAt   DateTime  @default(now())
+
+  @@index([keyHash])
 }

--- a/apps/api/src/auth/apikeys.resolver.ts
+++ b/apps/api/src/auth/apikeys.resolver.ts
@@ -1,0 +1,96 @@
+import { builder } from "../graphql/builder";
+import { requireAuth } from "../common/guards/auth";
+import { MutationResult, mutationOk, mutationError } from "../graphql/types";
+import { randomBytes, createHash } from "crypto";
+
+import "./apikeys.types";
+
+// Return type that includes the raw key (only shown once)
+const ApiKeyCreatedResult = builder.simpleObject("ApiKeyCreatedResult", {
+  fields: (t) => ({
+    ok: t.boolean(),
+    key: t.string({ nullable: true }),
+    errors: t.field({
+      type: [builder.simpleObject("ApiKeyError", {
+        fields: (t) => ({
+          field: t.string({ nullable: true }),
+          message: t.string(),
+        }),
+      })],
+      nullable: true,
+    }),
+  }),
+});
+
+function hashKey(key: string): string {
+  return createHash("sha256").update(key).digest("hex");
+}
+
+builder.queryField("apiKeys", (t) =>
+  t.prismaField({
+    type: ["ApiKey"],
+    resolve: (query, _root, _args, ctx) => {
+      requireAuth(ctx);
+      return ctx.prisma.apiKey.findMany({
+        ...query,
+        where: { createdById: ctx.user!.id },
+        orderBy: { createdAt: "desc" },
+      });
+    },
+  }),
+);
+
+builder.mutationField("createApiKey", (t) =>
+  t.field({
+    type: ApiKeyCreatedResult,
+    args: {
+      name: t.arg.string({ required: true }),
+      permissions: t.arg({ type: "JSON" }),
+      expiresInDays: t.arg.int(),
+    },
+    resolve: async (_root, args, ctx) => {
+      requireAuth(ctx);
+
+      const rawKey = `bw_live_${randomBytes(32).toString("hex")}`;
+      const keyHash = hashKey(rawKey);
+      const keyPrefix = rawKey.substring(0, 16);
+
+      const expiresAt = args.expiresInDays
+        ? new Date(Date.now() + args.expiresInDays * 24 * 60 * 60 * 1000)
+        : null;
+
+      await ctx.prisma.apiKey.create({
+        data: {
+          name: args.name,
+          keyHash,
+          keyPrefix,
+          permissions: (args.permissions as any) ?? [],
+          createdById: ctx.user!.id,
+          expiresAt,
+        },
+      });
+
+      return { ok: true, key: rawKey, errors: null };
+    },
+  }),
+);
+
+builder.mutationField("revokeApiKey", (t) =>
+  t.field({
+    type: MutationResult,
+    args: {
+      id: t.arg.string({ required: true }),
+    },
+    resolve: async (_root, args, ctx) => {
+      requireAuth(ctx);
+
+      const key = await ctx.prisma.apiKey.findFirst({
+        where: { id: args.id, createdById: ctx.user!.id },
+      });
+      if (!key) return mutationError(null, "API key not found");
+
+      await ctx.prisma.apiKey.delete({ where: { id: args.id } });
+      return mutationOk();
+    },
+  }),
+);

--- a/apps/api/src/auth/apikeys.types.ts
+++ b/apps/api/src/auth/apikeys.types.ts
@@ -1,0 +1,14 @@
+import { builder } from "../graphql/builder";
+
+builder.prismaObject("ApiKey", {
+  fields: (t) => ({
+    id: t.exposeID("id"),
+    name: t.exposeString("name"),
+    keyPrefix: t.exposeString("keyPrefix"),
+    permissions: t.expose("permissions", { type: "JSON" }),
+    lastUsedAt: t.expose("lastUsedAt", { type: "DateTime", nullable: true }),
+    expiresAt: t.expose("expiresAt", { type: "DateTime", nullable: true }),
+    createdAt: t.expose("createdAt", { type: "DateTime" }),
+    createdBy: t.relation("createdBy"),
+  }),
+});

--- a/apps/api/src/graphql/schema.ts
+++ b/apps/api/src/graphql/schema.ts
@@ -12,6 +12,8 @@ import "../workflows/workflows.resolver";
 import "../uploads/uploads.resolver";
 import "../notifications/notifications.resolver";
 import "../common/audit.resolver";
+import "../organizations/organizations.resolver";
+import "../auth/apikeys.resolver";
 
 // Register a simple health query to verify GraphQL is working
 builder.queryField("healthCheck", (t) =>

--- a/apps/api/src/organizations/organizations.resolver.ts
+++ b/apps/api/src/organizations/organizations.resolver.ts
@@ -1,0 +1,111 @@
+import { builder } from "../graphql/builder";
+import { requireAuth, requirePermission } from "../common/guards/auth";
+import { MutationResult, mutationOk, mutationError } from "../graphql/types";
+
+import "./organizations.types";
+
+builder.queryField("organizations", (t) =>
+  t.prismaField({
+    type: ["Organization"],
+    resolve: (query, _root, _args, ctx) => {
+      requireAuth(ctx);
+      return ctx.prisma.organization.findMany({
+        ...query,
+        where: { deletedAt: null },
+        orderBy: { name: "asc" },
+      });
+    },
+  }),
+);
+
+builder.queryField("organization", (t) =>
+  t.prismaField({
+    type: "Organization",
+    nullable: true,
+    args: { slug: t.arg.string({ required: true }) },
+    resolve: (query, _root, args, ctx) => {
+      requireAuth(ctx);
+      return ctx.prisma.organization.findFirst({
+        ...query,
+        where: { slug: args.slug, deletedAt: null },
+      });
+    },
+  }),
+);
+
+builder.mutationField("createOrganization", (t) =>
+  t.field({
+    type: MutationResult,
+    args: {
+      name: t.arg.string({ required: true }),
+      slug: t.arg.string({ required: true }),
+    },
+    resolve: async (_root, args, ctx) => {
+      requireAuth(ctx);
+
+      const existing = await ctx.prisma.organization.findUnique({
+        where: { slug: args.slug },
+      });
+      if (existing) return mutationError("slug", "Organization with this slug already exists");
+
+      const org = await ctx.prisma.organization.create({
+        data: { name: args.name, slug: args.slug },
+      });
+
+      // Creator becomes owner
+      await ctx.prisma.organizationMember.create({
+        data: { userId: ctx.user!.id, organizationId: org.id, role: "owner" },
+      });
+
+      return mutationOk();
+    },
+  }),
+);
+
+builder.mutationField("addOrganizationMember", (t) =>
+  t.field({
+    type: MutationResult,
+    args: {
+      organizationId: t.arg.string({ required: true }),
+      userId: t.arg.string({ required: true }),
+      role: t.arg.string(),
+    },
+    resolve: async (_root, args, ctx) => {
+      requireAuth(ctx);
+
+      try {
+        await ctx.prisma.organizationMember.create({
+          data: {
+            organizationId: args.organizationId,
+            userId: args.userId,
+            role: args.role ?? "member",
+          },
+        });
+      } catch {
+        return mutationError(null, "User already a member or invalid IDs");
+      }
+      return mutationOk();
+    },
+  }),
+);
+
+builder.mutationField("removeOrganizationMember", (t) =>
+  t.field({
+    type: MutationResult,
+    args: {
+      organizationId: t.arg.string({ required: true }),
+      userId: t.arg.string({ required: true }),
+    },
+    resolve: async (_root, args, ctx) => {
+      requireAuth(ctx);
+
+      await ctx.prisma.organizationMember.deleteMany({
+        where: {
+          organizationId: args.organizationId,
+          userId: args.userId,
+        },
+      });
+      return mutationOk();
+    },
+  }),
+);

--- a/apps/api/src/organizations/organizations.types.ts
+++ b/apps/api/src/organizations/organizations.types.ts
@@ -1,0 +1,23 @@
+import { builder } from "../graphql/builder";
+
+builder.prismaObject("Organization", {
+  fields: (t) => ({
+    id: t.exposeID("id"),
+    name: t.exposeString("name"),
+    slug: t.exposeString("slug"),
+    settings: t.expose("settings", { type: "JSON" }),
+    createdAt: t.expose("createdAt", { type: "DateTime" }),
+    members: t.relation("members"),
+    memberCount: t.relationCount("members"),
+  }),
+});
+
+builder.prismaObject("OrganizationMember", {
+  fields: (t) => ({
+    id: t.exposeID("id"),
+    role: t.exposeString("role"),
+    joinedAt: t.expose("joinedAt", { type: "DateTime" }),
+    user: t.relation("user"),
+    organization: t.relation("organization"),
+  }),
+});


### PR DESCRIPTION
## Summary
- Organization/tenancy model with member roles
- API key system for programmatic access
- Prisma schema updated with new models

## Organization
- `Organization` + `OrganizationMember` models (owner/admin/member roles)
- Queries: `organizations`, `organization(slug)`
- Mutations: `createOrganization`, `addOrganizationMember`, `removeOrganizationMember`
- Creator auto-assigned as owner

## API Keys
- `ApiKey` model with hashed storage (SHA-256)
- Format: `bw_live_<64 hex chars>` — prefix stored for identification
- `createApiKey` returns raw key once (never stored in plain text)
- `revokeApiKey` for deletion
- `apiKeys` query lists current user's keys

Closes #49, #91

## Note
Migration pending — run `npx prisma migrate dev` after Docker is up.

## Test plan
- [x] API builds cleanly with new models
- [x] Prisma client generated with new types