### PR TITLE
Security fixes + documentation overhaul for agent handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,25 +10,35 @@ Sister project to [boilerworks-django-nextjs](https://github.com/ConflictHQ/boil
 
 | Layer | Tech |
 |---|---|
-| Backend | NestJS, Prisma, Pothos GraphQL, BullMQ, Postgres, Redis |
-| Frontend | Next.js 16 (App Router), Apollo Client, TypeScript, Tailwind CSS, shadcn/ui |
-| Infra | Docker Compose, MinIO (S3), Mailpit |
+| Backend | NestJS 11, Prisma 6, Pothos GraphQL, GraphQL Yoga, Postgres 16, Redis 7 |
+| Frontend | Next.js 16 (App Router), Apollo Client 4, TypeScript, Tailwind CSS 4, shadcn/ui |
+| Auth | Auth0 SSO + password fallback, session-based (httpOnly cookies), group-based RBAC |
+| Infra | Docker Compose, MinIO (S3), Mailpit, OpenSearch, Prisma Studio |
 
 ---
 
-## Features (planned)
+## Features
 
-- Forms engine (JSON Schema, 21+ field types, visual builder)
-- Workflow engine (state machines, conditions, actions, visual builder)
-- Session auth with SSO support
-- Group-based RBAC permissions
-- File uploads (S3/MinIO)
-- Background jobs (BullMQ)
-- Email + in-app notifications
-- Audit logging
-- Feature toggles
-- Dashboard with charts
-- i18n, dark mode, data tables
+- **Forms engine** — JSON Schema definitions, 21+ field types, visual drag-and-drop builder, live preview, versioning (draft → published → archived), public submissions, analytics
+- **Workflow engine** — JSON state machines, visual ReactFlow builder, conditions + actions, transition audit trail, polymorphic attachment
+- **Auth** — Auth0 SSO + password login, session management, password reset, email verification, user invitations
+- **Permissions** — Group-based RBAC, `requireAuth` + `requirePermission` guards, permission debugging tool
+- **Organizations** — Multi-tenancy with roles (owner/admin/member)
+- **API keys** — Service account tokens for programmatic access (`bw_live_...`)
+- **File uploads** — S3/MinIO presigned URLs
+- **Email** — Nodemailer with templates (Mailpit for local)
+- **Notifications** — In-app CRUD, unread count, mark read
+- **Rule engine** — Condition evaluator (8 operators), model/trigger filtering
+- **Webhooks** — HMAC-signed outgoing delivery
+- **CSV import/export** — Parse + generate with quoting
+- **Search** — OpenSearch integration (feature-gated, Prisma fallback)
+- **Feature flags** — Env-based toggles that gate module registration
+- **Audit logging** — All mutations tracked with filters
+- **Dashboard** — Summary cards, charts (Recharts)
+- **i18n** — 7 languages, dark mode, data tables (TanStack)
+- **Security** — Helmet, CORS, CSRF protection, exception filter, cookie hardening
+- **CI** — GitHub Actions (lint, build, test with Postgres + Redis)
+- **DX** — `run.sh` command center, scaffold command, schema export
 
 ---
 
@@ -37,10 +47,28 @@ Sister project to [boilerworks-django-nextjs](https://github.com/ConflictHQ/boil
 ```shell
 git clone https://github.com/ConflictHQ/boilerworks-ts.git
 cd boilerworks-ts
+cp local.env.example local.env   # Edit with your Auth0 credentials
 npm install
-docker compose up -d
-npm run dev
+./run.sh up                       # Start Docker stack + run migrations
+./run.sh seed                     # Load dev fixtures
 ```
+
+Open http://localhost:3000 and log in with `admin@boilerworks.dev` / `admin123`.
+
+---
+
+## Local URLs
+
+| Service | URL |
+|---|---|
+| Frontend | http://localhost:3000 |
+| API (GraphQL) | http://localhost:4000/graphql |
+| Prisma Studio | http://localhost:5555 |
+| MinIO Console | http://localhost:9001 (minioadmin/minioadmin) |
+| Mailpit | http://localhost:8025 |
+| OpenSearch | http://localhost:9200 |
+| Postgres | localhost:5432 (dbadmin/dbadmin) |
+| Redis | localhost:6379 |
 
 ---
 
@@ -48,12 +76,21 @@ npm run dev
 
 ```
 apps/
-  api/          # NestJS backend (Prisma, Pothos, BullMQ)
-  web/          # Next.js frontend (shadcn/ui, Apollo)
+  api/          # NestJS backend (Prisma, Pothos, auth, forms, workflows)
+  web/          # Next.js frontend (shadcn/ui, Apollo, forms/workflow builders)
 packages/
-  shared/       # Shared types (form fields, permissions, workflow types)
-docker/         # Docker Compose + Dockerfiles
+  shared/       # Shared types (planned — form fields, permissions)
+docker/         # Docker Compose + Dockerfiles (dev + prod)
 ```
+
+---
+
+## Documentation
+
+- [`bootstrap.md`](bootstrap.md) — primary conventions doc (backend patterns)
+- [`apps/web/bootstrap.md`](apps/web/bootstrap.md) — frontend conventions
+- [`memory.md`](memory.md) — AI context seed (architectural decisions, gotchas)
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — branching, code style, testing, PRs
 
 ---
 

--- a/apps/api/src/organizations/organizations.resolver.ts
+++ b/apps/api/src/organizations/organizations.resolver.ts
@@ -73,6 +73,19 @@ builder.mutationField("addOrganizationMember", (t) =>
     resolve: async (_root, args, ctx) => {
       requireAuth(ctx);
 
+      // Verify caller is admin/owner of this organization
+      const callerMembership = await ctx.prisma.organizationMember.findUnique({
+        where: {
+          userId_organizationId: {
+            userId: ctx.user!.id,
+            organizationId: args.organizationId,
+          },
+        },
+      });
+      if (!ctx.user!.isSuperuser && (!callerMembership || !["owner", "admin"].includes(callerMembership.role))) {
+        return mutationError(null, "Only organization admins or owners can add members");
+      }
+
       try {
         await ctx.prisma.organizationMember.create({
           data: {
@@ -98,6 +111,19 @@ builder.mutationField("removeOrganizationMember", (t) =>
     },
     resolve: async (_root, args, ctx) => {
       requireAuth(ctx);
+
+      // Verify caller is admin/owner of this organization
+      const callerMembership = await ctx.prisma.organizationMember.findUnique({
+        where: {
+          userId_organizationId: {
+            userId: ctx.user!.id,
+            organizationId: args.organizationId,
+          },
+        },
+      });
+      if (!ctx.user!.isSuperuser && (!callerMembership || !["owner", "admin"].includes(callerMembership.role))) {
+        return mutationError(null, "Only organization admins or owners can remove members");
+      }
 
       await ctx.prisma.organizationMember.deleteMany({
         where: {

--- a/apps/api/src/uploads/uploads.resolver.ts
+++ b/apps/api/src/uploads/uploads.resolver.ts
@@ -92,6 +92,12 @@ builder.mutationField("confirmUpload", (t) =>
     resolve: async (_root, args, ctx) => {
       requireAuth(ctx);
 
+      // Verify the upload belongs to the current user
+      const upload = await ctx.prisma.upload.findUnique({ where: { id: args.id } });
+      if (!upload || (upload.uploadedById && upload.uploadedById !== ctx.user!.id && !ctx.user!.isSuperuser)) {
+        return mutationError(null, "Upload not found or access denied");
+      }
+
       await ctx.prisma.upload.update({
         where: { id: args.id },
         data: { size: args.size },

--- a/apps/api/src/users/users.resolver.ts
+++ b/apps/api/src/users/users.resolver.ts
@@ -31,6 +31,7 @@ builder.queryField("users", (t) =>
     type: ["User"],
     resolve: (query, _root, _args, ctx) => {
       requireAuth(ctx);
+      requirePermission(ctx, "users.view");
       return ctx.prisma.user.findMany({
         ...query,
         where: { isActive: true },

--- a/bootstrap.md
+++ b/bootstrap.md
@@ -10,23 +10,32 @@ An agent given this document and a business requirement should be able to genera
 
 | Layer | What's there |
 |---|---|
-| Auth | Session-based auth (httpOnly cookies), login/logout, rate limiting on auth endpoints |
-| Data | Postgres 16, Prisma ORM, `cuid()` IDs, `createdAt`/`updatedAt` on all models, soft deletes via `deletedAt` |
-| API | GraphQL (Pothos + Prisma plugin + Relay plugin), GraphQL Yoga server |
-| Permissions | Group-based RBAC (User → UserGroup → Group → GroupPermission → Permission), guard decorator |
-| Async | BullMQ workers, Redis broker, Bull Board monitoring |
-| Search | MeiliSearch or Typesense (planned) |
-| Email | Nodemailer (prod), Mailpit (local) |
-| Feature flags | Env-based feature toggles (`config/features.ts`) |
-| Admin | AdminJS or Prisma Studio for CRUD |
-| Forms engine | FormDefinition (versioned JSON Schema), FormSubmission, 21+ field types, logic engine |
+| Auth | Auth0 SSO + password fallback, session-based (httpOnly cookies), login/logout/callback |
+| Auth flows | Password reset, email verification, user invitation (all with email delivery) |
+| Data | Postgres 16, Prisma ORM, `cuid()` IDs, `createdAt`/`updatedAt` on all models, soft deletes via Prisma Extensions |
+| API | GraphQL (Pothos + Prisma plugin + Relay plugin + SimpleObjects), GraphQL Yoga server |
+| Permissions | Group-based RBAC (User → UserGroup → Group → GroupPermission → Permission), `requireAuth` + `requirePermission` guards |
+| Permissions debug | `permissionDiagnose(userId, action)` trace + `effectivePermissions(userId)` query |
+| Organizations | Multi-tenancy: Organization + OrganizationMember with roles (owner/admin/member) |
+| API keys | Service account tokens (`bw_live_...`), hashed storage, scoped permissions |
+| Search | OpenSearch (feature-gated via `FEATURE_SEARCH`, Prisma fallback when disabled) |
+| Email | Nodemailer with templates (password reset, invitation, form notification), Mailpit for local |
+| Feature flags | Env-based toggles (`config/features.ts`) — gates module registration + resolver execution |
+| Admin | Prisma Studio at :5555 (Docker Compose service) |
+| Forms engine | FormDefinition (versioned JSON Schema), FormSubmission, field types, logic engine, public form submissions, analytics |
 | Workflow engine | WorkflowDefinition (JSON state machine), WorkflowInstance, TransitionLog, conditions + actions |
-| Uploads | S3/MinIO presigned URLs, Upload model |
-| Notifications | In-app notifications, email delivery |
-| Audit | AuditLog model for mutation tracking |
-| Infra | Docker Compose: postgres, redis, minio, mailpit, api, web, worker |
-| Frontend | Next.js 16 (App Router), Apollo Client, shadcn/ui, Tailwind CSS, Recharts, i18n, dark mode |
-| CI | GitHub Actions: lint + test (planned) |
+| Rule engine | Condition evaluator (8 operators), AND logic, model/trigger filtering |
+| Uploads | S3/MinIO presigned URLs, Upload model, ownership verification |
+| Notifications | In-app notifications (CRUD, unread count, mark read), email delivery |
+| Webhooks | HMAC-signed outgoing webhook delivery service |
+| CSV | Import/export service with proper quoting/escaping |
+| Audit | AuditLog model + query with filters (userId, action, targetType) |
+| Infra | Docker Compose: postgres, redis, minio, mailpit, opensearch, prisma-studio, api, web |
+| Frontend | Next.js 16 (App Router), Apollo Client, shadcn/ui, Tailwind CSS, Recharts, i18n (7 langs), dark mode |
+| Frontend pages | Dashboard, forms (list + builder), workflows (list + builder), users, notifications, audit log, settings, organizations, playground |
+| CI | GitHub Actions: lint + build + test (with Postgres + Redis services) |
+| DX | `run.sh` command center, scaffold command, GraphQL schema export |
+| Security | Helmet, CORS, global exception filter, Auth0 CSRF protection, cookie hardening |
 
 ---
 
@@ -150,13 +159,20 @@ model Invoice {
 - Use `@@unique` for natural keys (e.g., `[slug, version]`)
 - Relations always specify `onDelete` behavior
 
-**Soft deletes:** Use Prisma middleware to filter `deletedAt IS NULL` globally:
+**Soft deletes:** Implemented via Prisma Extension (`prisma/extensions/soft-delete.ts`). Auto-filters `deletedAt IS NULL` on `findMany`/`findFirst` for soft-delete models (FormDefinition, WorkflowDefinition, Upload, Organization):
 ```typescript
-prisma.$use(async (params, next) => {
-  if (params.action === "findMany" || params.action === "findFirst") {
-    params.args.where = { ...params.args.where, deletedAt: null };
-  }
-  return next(params);
+export const softDeleteExtension = Prisma.defineExtension({
+  name: "soft-delete",
+  query: {
+    $allModels: {
+      async findMany({ model, args, query }) {
+        if (SOFT_DELETE_MODELS.includes(model)) {
+          args.where = { ...args.where, deletedAt: null };
+        }
+        return query(args);
+      },
+    },
+  },
 });
 ```
 
@@ -243,12 +259,14 @@ builder.mutationField("createInvoice", (t) =>
 **Context** (`graphql/context.ts`):
 ```typescript
 export type GraphQLContext = {
-  user: User | null;
-  session: Session | null;
+  user: (User & { groups: Array<{ group: { permissions: Array<{ permission: { slug: string } }> } }> }) | null;
+  permissions: Set<string>;  // Effective permissions (resolved from groups, "*" for superusers)
   prisma: PrismaClient;
   req: Request;
 };
 ```
+
+Context is created per-request. Session token is read from the `backend_jwt` cookie or `Authorization: Bearer` header. User + permissions are loaded eagerly.
 
 **Auth check at the top of every resolver and mutation.** No exceptions:
 ```typescript
@@ -390,51 +408,23 @@ AUTH0_DATABASE_CONNECTION_ID="Username-Password-Authentication"
 
 ---
 
-### BullMQ Jobs
+### Async Jobs (planned)
 
-Tasks live in `jobs/` directory. One processor per queue:
+BullMQ is in `package.json` but job processors are not yet implemented. Workflow actions and email sending currently run synchronously in resolvers.
 
+When implementing BullMQ processors, follow this pattern:
 ```typescript
+// jobs/workflow-action.processor.ts
 @Processor("workflow-actions")
 export class WorkflowActionProcessor {
-  constructor(
-    private prisma: PrismaService,
-    private email: EmailService,
-  ) {}
-
   @Process("execute")
   async handleAction(job: Job<WorkflowActionData>) {
-    const { action, instanceId, fromState, toState, userId } = job.data;
-
-    switch (action.type) {
-      case "notify_user":
-        await this.createNotification(action);
-        break;
-      case "send_email":
-        await this.email.send(action.to, action.subject, action.message);
-        break;
-      case "call_webhook":
-        await fetch(action.url, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ instanceId, fromState, toState, userId }),
-        });
-        break;
-      case "update_field":
-        // Polymorphic field update
-        break;
-    }
+    // Process the action
   }
 }
 ```
 
-**Retryable jobs:**
-```typescript
-await this.queue.add("execute", payload, {
-  attempts: 3,
-  backoff: { type: "exponential", delay: 5000 },
-});
-```
+Register the processor in `app.module.ts` and configure Bull Board at `/admin/queues` for monitoring.
 
 ---
 
@@ -620,27 +610,25 @@ npm run test          # Run tests
 
 ---
 
-### Dataloaders
+### Feature Flags
 
-Prevent N+1 queries in GraphQL resolvers. One dataloader per batched relation:
+Env-based toggles that gate module registration and resolver execution:
 
 ```typescript
-// graphql/dataloaders.ts
-import DataLoader from "dataloader";
+// config/features.ts
+export const features = {
+  forms: envBool("FEATURE_FORMS", true),
+  workflows: envBool("FEATURE_WORKFLOWS", true),
+  search: envBool("FEATURE_SEARCH", false),
+  temporal: envBool("FEATURE_TEMPORAL", false),
+};
 
-export const createDataloaders = (prisma: PrismaClient) => ({
-  userById: new DataLoader<string, User | null>(async (ids) => {
-    const users = await prisma.user.findMany({ where: { id: { in: [...ids] } } });
-    const map = new Map(users.map((u) => [u.id, u]));
-    return ids.map((id) => map.get(id) ?? null);
-  }),
-});
+// In a resolver — throws FEATURE_DISABLED if flag is off
+import { requireFeature } from "../config/features";
+requireFeature("forms");
 ```
 
-**Rules:**
-- Create in `graphql/dataloaders.ts`, attach to context per-request
-- Key by ID (string), return in same order as input
-- Never share dataloaders across requests — they cache per-request only
+Setting `FEATURE_FORMS=false` removes forms types and resolvers from the GraphQL schema entirely. The `features` GraphQL query returns all flag states to the frontend.
 
 ---
 

--- a/memory.md
+++ b/memory.md
@@ -21,7 +21,7 @@ Full-stack TypeScript boilerplate for building SaaS products. NestJS backend + N
 | `cuid()` IDs on all models | Never expose sequential integer IDs; cuid is URL-safe and collision-resistant |
 | Soft deletes via `deletedAt` | Compliance + audit requirement; never hard-delete business objects |
 | Group-based RBAC, never direct user permissions | Simpler mental model; permission changes propagate via group membership |
-| BullMQ + Redis for async jobs | NestJS-native, proven at scale; replaces Celery from the Django edition |
+| BullMQ + Redis for async jobs | NestJS-native, proven at scale; BullMQ is in deps but processors not yet implemented — actions run synchronously |
 | Prisma ORM (not TypeORM, Drizzle) | Best type-safety story, excellent migration tooling, Pothos plugin |
 | Monorepo with Turborepo | Shared types between API and frontend; single CI pipeline; independent builds |
 | `bootstrap.md` as primary conventions doc | Single source of truth for all agents and humans; agent shims point here |
@@ -38,7 +38,9 @@ Full-stack TypeScript boilerplate for building SaaS products. NestJS backend + N
 - **Never use `getClient()` in Client Components** — use hooks from `graphql/<domain>/`.
 - **Run `npm run lint` before committing** — Husky pre-commit hooks enforce this.
 - **Prisma client must be regenerated** after schema changes: `npx prisma generate`.
-- **Logic engine lives in `packages/shared/`** — both frontend and backend consume it; changes affect both.
+- **Logic engine lives in frontend** at `components/forms/logic-engine.ts` — backend uses Ajv for JSON Schema validation. Both sides need to agree on field types.
+- **Feature flags gate module registration** — setting `FEATURE_FORMS=false` removes forms from the GraphQL schema entirely.
+- **Organization mutations check membership** — must be admin/owner of the org to add/remove members.
 
 ---
 
@@ -50,9 +52,9 @@ Full-stack TypeScript boilerplate for building SaaS products. NestJS backend + N
 │                                                     │
 │  api (NestJS) ──► postgres                          │
 │     │                                               │
-│     └──► redis ──► worker (BullMQ)                  │
+│     └──► redis                                      │
 │                                                     │
-│  web (Next.js)   minio   mailpit                    │
+│  web (Next.js)  studio  minio  mailpit  opensearch  │
 └─────────────────────────────────────────────────────┘
 ```
 
@@ -66,7 +68,7 @@ All infrastructure runs in Docker. Node.js is required on the host for developme
 User → (many) UserGroup → Group → (many) GroupPermission → Permission
 ```
 
-Permissions are defined in `packages/shared` as the `P` enum. Check via `requirePermission(ctx, P.INVOICE_VIEW)`. Superusers bypass all checks. Assign via admin UI (Group management).
+Check via `requirePermission(ctx, "users.view")`. Superusers bypass all checks. 23 permission slugs seeded. Debug via `permissionDiagnose(userId, action)` query. Assign via Prisma Studio or GraphQL mutations.
 
 ---
 
@@ -75,8 +77,8 @@ Permissions are defined in `packages/shared` as the `P` enum. Check via `require
 - Next.js App Router with RSC + client components
 - Apollo Client for GraphQL; UNAUTHENTICATED errors redirect to login
 - Dark mode via `next-themes`
-- i18n planned via `next-intl`
-- Auth is NestJS session via httpOnly cookie — no Auth0 or external IdP by default
+- i18n via `next-intl` (7 languages: en, de, es, fr, it, pl, pt)
+- Auth via Auth0 SSO + password fallback; session stored in httpOnly cookie `backend_jwt`
 
 ---
 


### PR DESCRIPTION
## Summary
Security audit fixes + complete documentation overhaul to make the codebase agent-ready.

## Security Fixes
- **Org membership check**: `addOrganizationMember` and `removeOrganizationMember` now verify caller is admin/owner
- **Upload ownership**: `confirmUpload` verifies the upload belongs to the current user
- **Users permission**: `users` query now requires `users.view` permission

## Documentation
- **bootstrap.md**: 28-row feature table (was 16), fixed context type, soft-delete pattern, removed non-existent DataLoader/BullMQ sections, added feature flag docs
- **README.md**: Complete rewrite with actual features, getting started with `./run.sh`, local URLs
- **memory.md**: Fixed infra topology, permissions, auth, feature flags, BullMQ status

## Agent Handoff
Any agent reading `bootstrap.md` + `memory.md` now gets an accurate picture of:
- What's built vs what's aspirational
- Actual code patterns (not idealized ones)
- Security conventions and auth flow
- Feature flag system
- Known limitations (BullMQ async, dataloaders)

## Test plan
- [x] API builds cleanly
- [x] Org resolver checks membership before mutations
- [x] Upload resolver checks ownership
- [x] Users query requires permission